### PR TITLE
Remove unnecessary dependency on `proto-lens-protobuf-types`.

### DIFF
--- a/proto/package.yaml
+++ b/proto/package.yaml
@@ -10,7 +10,6 @@ library:
     - base
     - proto-lens
     - proto-lens-protoc
-    - proto-lens-protobuf-types
 
   exposed-modules:
     - Proto.Person

--- a/stack.yaml
+++ b/stack.yaml
@@ -45,7 +45,6 @@ packages:
     commit: master
   subdirs:
     - proto-lens
-    - proto-lens-protobuf-types
     - proto-lens-protoc
     - lens-labels
 


### PR DESCRIPTION
That package provides wrappers around some standard proto messages such as
those in `wrappers.proto` or `any.proto`, but isn't required to compile
arbitrary `.proto` files that don't import one of those.